### PR TITLE
feat: LiteLLM PDF parser with Claude fallback and statement processing fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,9 @@ repos:
           - pandas
           - google-api-python-client
           - oauth2client
+          - pypdf
+          - google-generativeai
+          - reportlab
       - id: diff-coverage
         name: diff-coverage
         # The entry no longer needs a hardcoded path

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
           - google-api-python-client
           - oauth2client
           - pypdf
-          - google-generativeai
+          - litellm
           - reportlab
       - id: diff-coverage
         name: diff-coverage

--- a/plugins/gmail_fetcher/fetcher.py
+++ b/plugins/gmail_fetcher/fetcher.py
@@ -34,6 +34,8 @@ class GmailFetcher:
             logger.error(f"Failed to load settings.json: {e}")
             return None
 
+    _OAUTH_PORT = 8081
+
     def _get_gmail_service(self):
         creds = None
         # Put credentials in the root secrets/ folder
@@ -54,24 +56,31 @@ class GmailFetcher:
                     )
                     return None
                 flow = InstalledAppFlow.from_client_secrets_file(creds_path, SCOPES)
-                # Headless server support: print URL, user opens locally, then redirects to localhost
+                port = self._OAUTH_PORT
                 logger.info("\n" + "=" * 80)
-                logger.info("HEADLESS AUTHENTICATION REQUIRED")
                 logger.info(
-                    "1. Copy the URL printed below and open it in a browser on your local computer."
+                    "HEADLESS AUTHENTICATION — two steps before opening the URL:"
                 )
-                logger.info("2. Complete the Google login.")
+                logger.info("")
                 logger.info(
-                    "3. You will be redirected to a 'This site can't be reached' page (localhost:8080)."
-                )
-                logger.info(
-                    "4. Copy the ENTIRE localhost URL from your browser's address bar."
+                    "STEP 1: In a NEW terminal on your LOCAL machine, open an SSH tunnel:"
                 )
                 logger.info(
-                    '5. Open a NEW terminal on this server and run: curl "<PASTE_URL_HERE>"'
+                    f"        ssh -L {port}:localhost:{port} <user>@<this-server-ip>"
+                )
+                logger.info("")
+                logger.info("STEP 2: Open this URL in your local browser:")
+                # Generate and print the URL so user can see it before run_local_server blocks
+                flow.redirect_uri = f"http://localhost:{port}/"
+                auth_url, _ = flow.authorization_url(prompt="consent")
+                logger.info(f"        {auth_url}")
+                logger.info("")
+                logger.info(
+                    "After you approve access, the browser will redirect to localhost "
+                    f"(port {port}) through the tunnel. Auth completes automatically."
                 )
                 logger.info("=" * 80 + "\n")
-                creds = flow.run_local_server(port=0, open_browser=False)
+                creds = flow.run_local_server(port=port, open_browser=False)
 
             with open(token_path, "w") as token:
                 token.write(creds.to_json())

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ pytest-mock
 pytest-cov
 mypy
 pypdf
-google-generativeai
+litellm
 reportlab

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,6 @@ pytest
 pytest-mock
 pytest-cov
 mypy
+pypdf
+google-generativeai
+reportlab

--- a/src/constants.py
+++ b/src/constants.py
@@ -47,7 +47,7 @@ SERVICE_ACCOUNT_KEY_FILE = "secrets/google.json"
 DB_FILE_PATH = "backups/gajana.db"
 
 # --- Google Drive Configuration ---
-CSV_FOLDER = "1DwJGCYydYikP7eWxMWD6mA84Mj7fO7-3"
+CSV_FOLDER = "1WkQUCUv44WvTr2pX51waJpRYnVvEWDjH"
 
 # --- Google Sheets Configuration ---
 TRANSACTIONS_SHEET_ID = "1I1NkOf2L5hVB6_yV896x9H-s1CIsRYWTR2T0ioBZDZU"

--- a/src/csv_data_source.py
+++ b/src/csv_data_source.py
@@ -75,11 +75,15 @@ class CSVDataSource(DataSourceInterface):
             return files_details
 
         for filename in os.listdir(self.statements_path):
-            if filename.endswith(".csv") or filename.endswith(".gsheet.csv"):
+            if (
+                filename.endswith(".csv")
+                or filename.endswith(".gsheet.csv")
+                or filename.endswith(".pdf")
+            ):
                 # We use the filename as the ID for local files
                 files_details.append(DataSourceFile(filename, filename))
 
-        self.logger.info(f"Found {len(files_details)} CSV statement files.")
+        self.logger.info(f"Found {len(files_details)} statement files.")
         return files_details
 
     def get_sheet_data(
@@ -169,3 +173,14 @@ class CSVDataSource(DataSourceInterface):
     def get_first_sheet_name_from_file(self, file_id: str) -> Optional[str]:
         """For CSV, we just return the filename or a dummy value."""
         return "Sheet1"
+
+    def download_file(self, file_id: str) -> bytes:
+        """Reads and returns the raw bytes of a local statement file."""
+        file_path = os.path.join(self.statements_path, file_id)
+        if not os.path.exists(file_path):
+            file_path = os.path.join(self.root_path, file_id)
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found: {file_path}")
+        self.logger.debug(f"Downloading/reading local file bytes: {file_path}")
+        with open(file_path, "rb") as f:
+            return f.read()

--- a/src/google_data_source.py
+++ b/src/google_data_source.py
@@ -131,7 +131,11 @@ class GoogleDataSource(DataSourceInterface):
         files_details: List[DataSourceFile] = []
         page_token = None
         logger.info(f"Listing Google Sheets from Drive folder ID: {CSV_FOLDER}")
-        query = f"parents in '{CSV_FOLDER}' and mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
+        query = (
+            f"parents in '{CSV_FOLDER}' and "
+            "(mimeType='application/vnd.google-apps.spreadsheet' or "
+            "mimeType='application/pdf') and trashed=false"
+        )
         try:
             while True:
                 response = (
@@ -183,8 +187,23 @@ class GoogleDataSource(DataSourceInterface):
                         f"Found first visible sheet name: '{title}' for file ID: {file_id}"
                     )
                     return title
-        logger.warning(f"No visible sheets found for file ID: {file_id}")
         return None
+
+    @retry_on_gcp_error()
+    def download_file(self, file_id: str) -> bytes:
+        """Downloads a file (e.g., PDF) from Google Drive."""
+        from googleapiclient.http import MediaIoBaseDownload
+        import io
+
+        logger.info(f"Downloading file ID: {file_id}")
+        request = self.drive_service.files().get_media(fileId=file_id)
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while done is False:
+            status, done = downloader.next_chunk()
+        logger.info(f"Successfully downloaded file ID: {file_id}")
+        return fh.getvalue()
 
     @retry_on_gcp_error()
     def get_sheet_data(

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -101,6 +101,11 @@ class DataSourceInterface(abc.ABC):
         """Gets the name (title) of the first visible sheet in a spreadsheet file."""
         pass
 
+    @abc.abstractmethod
+    def download_file(self, file_id: str) -> bytes:
+        """Downloads/reads a file's raw content and returns its bytes."""
+        pass
+
 
 class BackupInterface(abc.ABC):
     """

--- a/src/pdf_parser.py
+++ b/src/pdf_parser.py
@@ -2,69 +2,185 @@ import os
 import json
 import logging
 import io
+import base64
 from pypdf import PdfReader, PdfWriter
-import google.generativeai as genai
+import litellm
 
 logger = logging.getLogger(__name__)
 
+PRIMARY_MODEL = "gemini/gemini-2.5-flash"
+FALLBACK_MODEL = "anthropic/claude-sonnet-4-6"
 
-def load_gemini_api_key() -> str:
-    # 1. Try secrets/gemini.json
-    json_path = os.path.join(os.getcwd(), "secrets", "gemini.json")
+_quota_exhausted_models: set[str] = set()
+
+_EXTRACTION_PROMPT = """
+You are a precise data extraction assistant.
+Extract all financial transactions from the provided bank statement.
+Only extract actual transactions. Ignore opening/closing balances, rewards points, page headers, or other summary text.
+
+Return a JSON object with a single key "transactions" containing an array of objects.
+Each object must have exactly these fields:
+- "date": The transaction date in YYYY-MM-DD format.
+- "description": The exact transaction details, description, narration, or payee.
+- "debit": The outgoing amount (withdrawal/debit). Use empty string if no debit occurred. No currency symbols or commas.
+- "credit": The incoming amount (deposit/credit). Use empty string if no credit occurred. No currency symbols or commas.
+"""
+
+
+def _load_secret_key(filename: str, env_var: str) -> str:
+    import re
+
+    json_path = os.path.join(os.getcwd(), "secrets", filename)
     if os.path.exists(json_path):
         try:
             with open(json_path, "r", encoding="utf-8") as f:
                 content = f.read().strip()
-            # If missing curly braces, wrap it
             if not content.startswith("{"):
                 content = "{" + content + "}"
-            data = json.loads(content)
-            if "api_key" in data:
-                return str(data["api_key"]).strip()
+            try:
+                data = json.loads(content)
+                if "api_key" in data:
+                    return str(data["api_key"]).strip()
+            except Exception:
+                match = re.search(r'"api_key"\s*:\s*"([^"]+)"', content)
+                if match:
+                    return match.group(1).strip()
         except Exception:
-            # Fallback regex extraction if JSON parsing is still problematic
-            import re
+            pass
+    return os.environ.get(env_var, "")
 
-            match = re.search(r'"api_key"\s*:\s*"([^"]+)"', content)
-            if match:
-                return match.group(1).strip()
 
-    # 2. Try environment variable
-    return os.environ.get("GEMINI_API_KEY", "")
+def configure_api_keys() -> None:
+    """Load API keys from secrets files into env vars for LiteLLM."""
+    gemini_key = _load_secret_key("gemini.json", "GEMINI_API_KEY")
+    if gemini_key:
+        os.environ.setdefault("GEMINI_API_KEY", gemini_key)
+
+    anthropic_key = _load_secret_key("anthropic.json", "ANTHROPIC_API_KEY")
+    if anthropic_key:
+        os.environ.setdefault("ANTHROPIC_API_KEY", anthropic_key)
+
+
+def has_any_api_key() -> bool:
+    return bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("ANTHROPIC_API_KEY"))
 
 
 class PDFParser:
-    def __init__(self, model_name: str = "gemini-3.5-flash"):
-        api_key = load_gemini_api_key()
-        if api_key:
-            genai.configure(api_key=api_key)
-            self.model = genai.GenerativeModel(model_name)
-            logger.info(f"PDFParser initialized with model: {model_name}")
+    def __init__(
+        self,
+        primary_model: str = PRIMARY_MODEL,
+        fallback_model: str = FALLBACK_MODEL,
+    ):
+        configure_api_keys()
+        self.primary_model = primary_model
+        self.fallback_model = fallback_model
+        if not has_any_api_key():
+            logger.warning("No LLM API keys configured. PDF parsing will fail.")
         else:
-            logger.warning(
-                "GEMINI_API_KEY environment variable or secrets/gemini.json not set. PDF parsing will fail."
+            logger.info(
+                f"PDFParser ready. Primary: {primary_model}, Fallback: {fallback_model}"
             )
-            self.model = None
+
+    def _parse_response(self, content: str, tool_calls=None) -> list[dict]:
+        if not content and tool_calls:
+            content = tool_calls[0].function.arguments
+        text = content.strip()
+        # Strip markdown code fences (```json ... ``` or ``` ... ```)
+        if text.startswith("```"):
+            lines = text.splitlines()
+            lines = lines[1:]  # drop opening fence line
+            if lines and lines[-1].strip().startswith("```"):
+                lines = lines[:-1]
+            text = "\n".join(lines).strip()
+        data = json.loads(text)
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for val in data.values():
+                if isinstance(val, list):
+                    return val
+        return []
+
+    def _call_llm_with_pdf(self, model: str, pdf_b64: str) -> list[dict]:
+        if model in _quota_exhausted_models:
+            raise litellm.RateLimitError(
+                f"Skipping {model}: quota known exhausted this session.",
+                llm_provider="",
+                model=model,
+            )
+        # Anthropic requires "document" content block; others use image_url
+        if "anthropic" in model or "claude" in model:
+            pdf_content: dict = {
+                "type": "document",
+                "source": {
+                    "type": "base64",
+                    "media_type": "application/pdf",
+                    "data": pdf_b64,
+                },
+            }
+        else:
+            pdf_content = {
+                "type": "image_url",
+                "image_url": {"url": f"data:application/pdf;base64,{pdf_b64}"},
+            }
+        try:
+            response = litellm.completion(
+                model=model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": _EXTRACTION_PROMPT},
+                            pdf_content,
+                        ],
+                    }
+                ],
+                response_format={"type": "json_object"},
+            )
+        except litellm.RateLimitError:
+            _quota_exhausted_models.add(model)
+            raise
+        msg = response.choices[0].message
+        return self._parse_response(msg.content or "", msg.tool_calls)
+
+    def _call_llm_with_text(self, model: str, text: str) -> list[dict]:
+        if model in _quota_exhausted_models:
+            raise litellm.RateLimitError(
+                f"Skipping {model}: quota known exhausted this session.",
+                llm_provider="",
+                model=model,
+            )
+        try:
+            response = litellm.completion(
+                model=model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"{_EXTRACTION_PROMPT}\n\nStatement Text:\n{text}",
+                    }
+                ],
+                response_format={"type": "json_object"},
+            )
+        except litellm.RateLimitError:
+            _quota_exhausted_models.add(model)
+            raise
+        msg = response.choices[0].message
+        return self._parse_response(msg.content or "", msg.tool_calls)
 
     def parse_pdf(self, pdf_bytes: bytes, password: str = "") -> list[dict]:
-        if not self.model:
-            logger.error("GEMINI_API_KEY not configured. Cannot parse PDF.")
+        if not has_any_api_key():
+            logger.error("No LLM API keys configured. Cannot parse PDF.")
             return []
 
         try:
             reader = PdfReader(io.BytesIO(pdf_bytes))
             if reader.is_encrypted:
-                if password:
-                    res = reader.decrypt(password)
-                    if res == 0:
-                        logger.error("Failed to decrypt PDF. Incorrect password.")
-                        return []
-                else:
+                if not password:
                     logger.error("PDF is encrypted but no password provided.")
                     return []
-
-            # If it was encrypted, write the decrypted PDF to bytes
-            if reader.is_encrypted:
+                if reader.decrypt(password) == 0:
+                    logger.error("Failed to decrypt PDF. Incorrect password.")
+                    return []
                 writer = PdfWriter()
                 for page in reader.pages:
                     writer.add_page(page)
@@ -74,108 +190,53 @@ class PDFParser:
             else:
                 pdf_payload_bytes = pdf_bytes
 
-            prompt = """
-You are a precise data extraction assistant.
-Extract all financial transactions from the provided bank statement document.
-Only extract actual transactions. Ignore opening/closing balances, rewards points, page headers, or other summary text.
+            pdf_b64 = base64.b64encode(pdf_payload_bytes).decode("utf-8")
 
-For each transaction, extract:
-- 'date': The transaction date in YYYY-MM-DD format.
-- 'description': The exact transaction details, description, narration, or payee.
-- 'debit': The outgoing amount (withdrawal / debit). Use empty string if no debit occurred.
-  Do not include currency symbols or commas.
-- 'credit': The incoming amount (deposit / credit). Use empty string if no credit occurred.
-  Do not include currency symbols or commas.
-"""
-
-            # Define standard schema for structured JSON output
-            generation_config = {
-                "response_mime_type": "application/json",
-                "response_schema": {
-                    "type": "ARRAY",
-                    "description": "List of extracted transactions",
-                    "items": {
-                        "type": "OBJECT",
-                        "properties": {
-                            "date": {
-                                "type": "STRING",
-                                "description": "Transaction date in YYYY-MM-DD format",
-                            },
-                            "description": {
-                                "type": "STRING",
-                                "description": "Transaction description/narration",
-                            },
-                            "debit": {
-                                "type": "STRING",
-                                "description": "Debit amount as string",
-                            },
-                            "credit": {
-                                "type": "STRING",
-                                "description": "Credit amount as string",
-                            },
-                        },
-                        "required": ["date", "description", "debit", "credit"],
-                    },
-                },
-            }
-
-            response_text = ""
-            # Try native PDF modality first
+            # 1. Primary model with PDF
             try:
+                logger.info(f"Parsing PDF with primary model: {self.primary_model}")
+                txns = self._call_llm_with_pdf(self.primary_model, pdf_b64)
                 logger.info(
-                    "Attempting to parse PDF using Gemini native PDF modality..."
+                    f"Parsed {len(txns)} transactions via {self.primary_model}."
                 )
-                response = self.model.generate_content(
-                    contents=[
-                        {
-                            "mime_type": "application/pdf",
-                            "data": pdf_payload_bytes,
-                        },
-                        prompt,
-                    ],
-                    generation_config=generation_config,
-                )
-                response_text = response.text.strip()
-                transactions = json.loads(response_text)
+                return txns
+            except Exception as e:
+                logger.warning(f"Primary model failed: {e}. Trying fallback...")
+
+            # 2. Fallback model with PDF
+            try:
+                logger.info(f"Parsing PDF with fallback model: {self.fallback_model}")
+                txns = self._call_llm_with_pdf(self.fallback_model, pdf_b64)
                 logger.info(
-                    f"Successfully parsed {len(transactions)} transactions via Gemini PDF modality."
+                    f"Parsed {len(txns)} transactions via {self.fallback_model}."
                 )
-                return transactions
+                return txns
+            except Exception as e:
+                logger.warning(f"Fallback model failed: {e}. Trying text extraction...")
 
-            except Exception as pdf_err:
-                logger.warning(
-                    f"Native PDF modality parsing failed or timed out: {pdf_err}. Falling back to text extraction..."
-                )
-                # Fallback: Extract text using pypdf
-                text = ""
-                for page in reader.pages:
-                    extracted = page.extract_text()
-                    if extracted:
-                        text += extracted + "\n"
+            # 3. Text extraction — try primary then fallback
+            text = "".join(page.extract_text() or "" for page in reader.pages)
+            if not text.strip():
+                logger.error("No text extractable from PDF. Cannot parse.")
+                return []
 
-                if not text.strip():
-                    logger.error(
-                        "No text could be extracted from PDF using pypdf. Cannot parse."
+            for model in (self.primary_model, self.fallback_model):
+                try:
+                    logger.info(f"Parsing extracted text with: {model}")
+                    txns = self._call_llm_with_text(model, text)
+                    logger.info(
+                        f"Parsed {len(txns)} transactions via text extraction ({model})."
                     )
-                    return []
+                    return txns
+                except Exception as e:
+                    logger.warning(f"Text extraction with {model} failed: {e}")
 
-                logger.info("Attempting to parse extracted text using Gemini...")
-                text_prompt = f"{prompt}\n\nStatement Text:\n{text}"
-                response = self.model.generate_content(
-                    contents=text_prompt, generation_config=generation_config
-                )
-                response_text = response.text.strip()
-                transactions = json.loads(response_text)
-                logger.info(
-                    f"Successfully parsed {len(transactions)} transactions via extracted text."
-                )
-                return transactions
+            logger.error("All models failed on text extraction.")
+            return []
 
         except json.JSONDecodeError as e:
-            logger.error(
-                f"Failed to decode JSON from Gemini response: {e}\nResponse: {response_text}"
-            )
+            logger.error(f"Failed to parse LLM JSON response: {e}")
             return []
         except Exception as e:
-            logger.error(f"Failed to parse PDF statement: {e}")
+            logger.error(f"Failed to parse PDF: {e}")
             return []

--- a/src/pdf_parser.py
+++ b/src/pdf_parser.py
@@ -1,0 +1,181 @@
+import os
+import json
+import logging
+import io
+from pypdf import PdfReader, PdfWriter
+import google.generativeai as genai
+
+logger = logging.getLogger(__name__)
+
+
+def load_gemini_api_key() -> str:
+    # 1. Try secrets/gemini.json
+    json_path = os.path.join(os.getcwd(), "secrets", "gemini.json")
+    if os.path.exists(json_path):
+        try:
+            with open(json_path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+            # If missing curly braces, wrap it
+            if not content.startswith("{"):
+                content = "{" + content + "}"
+            data = json.loads(content)
+            if "api_key" in data:
+                return str(data["api_key"]).strip()
+        except Exception:
+            # Fallback regex extraction if JSON parsing is still problematic
+            import re
+
+            match = re.search(r'"api_key"\s*:\s*"([^"]+)"', content)
+            if match:
+                return match.group(1).strip()
+
+    # 2. Try environment variable
+    return os.environ.get("GEMINI_API_KEY", "")
+
+
+class PDFParser:
+    def __init__(self, model_name: str = "gemini-3.5-flash"):
+        api_key = load_gemini_api_key()
+        if api_key:
+            genai.configure(api_key=api_key)
+            self.model = genai.GenerativeModel(model_name)
+            logger.info(f"PDFParser initialized with model: {model_name}")
+        else:
+            logger.warning(
+                "GEMINI_API_KEY environment variable or secrets/gemini.json not set. PDF parsing will fail."
+            )
+            self.model = None
+
+    def parse_pdf(self, pdf_bytes: bytes, password: str = "") -> list[dict]:
+        if not self.model:
+            logger.error("GEMINI_API_KEY not configured. Cannot parse PDF.")
+            return []
+
+        try:
+            reader = PdfReader(io.BytesIO(pdf_bytes))
+            if reader.is_encrypted:
+                if password:
+                    res = reader.decrypt(password)
+                    if res == 0:
+                        logger.error("Failed to decrypt PDF. Incorrect password.")
+                        return []
+                else:
+                    logger.error("PDF is encrypted but no password provided.")
+                    return []
+
+            # If it was encrypted, write the decrypted PDF to bytes
+            if reader.is_encrypted:
+                writer = PdfWriter()
+                for page in reader.pages:
+                    writer.add_page(page)
+                out_buf = io.BytesIO()
+                writer.write(out_buf)
+                pdf_payload_bytes = out_buf.getvalue()
+            else:
+                pdf_payload_bytes = pdf_bytes
+
+            prompt = """
+You are a precise data extraction assistant.
+Extract all financial transactions from the provided bank statement document.
+Only extract actual transactions. Ignore opening/closing balances, rewards points, page headers, or other summary text.
+
+For each transaction, extract:
+- 'date': The transaction date in YYYY-MM-DD format.
+- 'description': The exact transaction details, description, narration, or payee.
+- 'debit': The outgoing amount (withdrawal / debit). Use empty string if no debit occurred.
+  Do not include currency symbols or commas.
+- 'credit': The incoming amount (deposit / credit). Use empty string if no credit occurred.
+  Do not include currency symbols or commas.
+"""
+
+            # Define standard schema for structured JSON output
+            generation_config = {
+                "response_mime_type": "application/json",
+                "response_schema": {
+                    "type": "ARRAY",
+                    "description": "List of extracted transactions",
+                    "items": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "date": {
+                                "type": "STRING",
+                                "description": "Transaction date in YYYY-MM-DD format",
+                            },
+                            "description": {
+                                "type": "STRING",
+                                "description": "Transaction description/narration",
+                            },
+                            "debit": {
+                                "type": "STRING",
+                                "description": "Debit amount as string",
+                            },
+                            "credit": {
+                                "type": "STRING",
+                                "description": "Credit amount as string",
+                            },
+                        },
+                        "required": ["date", "description", "debit", "credit"],
+                    },
+                },
+            }
+
+            response_text = ""
+            # Try native PDF modality first
+            try:
+                logger.info(
+                    "Attempting to parse PDF using Gemini native PDF modality..."
+                )
+                response = self.model.generate_content(
+                    contents=[
+                        {
+                            "mime_type": "application/pdf",
+                            "data": pdf_payload_bytes,
+                        },
+                        prompt,
+                    ],
+                    generation_config=generation_config,
+                )
+                response_text = response.text.strip()
+                transactions = json.loads(response_text)
+                logger.info(
+                    f"Successfully parsed {len(transactions)} transactions via Gemini PDF modality."
+                )
+                return transactions
+
+            except Exception as pdf_err:
+                logger.warning(
+                    f"Native PDF modality parsing failed or timed out: {pdf_err}. Falling back to text extraction..."
+                )
+                # Fallback: Extract text using pypdf
+                text = ""
+                for page in reader.pages:
+                    extracted = page.extract_text()
+                    if extracted:
+                        text += extracted + "\n"
+
+                if not text.strip():
+                    logger.error(
+                        "No text could be extracted from PDF using pypdf. Cannot parse."
+                    )
+                    return []
+
+                logger.info("Attempting to parse extracted text using Gemini...")
+                text_prompt = f"{prompt}\n\nStatement Text:\n{text}"
+                response = self.model.generate_content(
+                    contents=text_prompt, generation_config=generation_config
+                )
+                response_text = response.text.strip()
+                transactions = json.loads(response_text)
+                logger.info(
+                    f"Successfully parsed {len(transactions)} transactions via extracted text."
+                )
+                return transactions
+
+        except json.JSONDecodeError as e:
+            logger.error(
+                f"Failed to decode JSON from Gemini response: {e}\nResponse: {response_text}"
+            )
+            return []
+        except Exception as e:
+            logger.error(f"Failed to parse PDF statement: {e}")
+            return []

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -68,33 +68,35 @@ class TransactionProcessor:
             return None, None
 
         try:
-            # Remove extensions
+            import re as _re
+
             base_name = filename_lower.split(".")[0]
+            base_name = _re.sub(r"_copy\d+$", "", base_name)
             parts = base_name.split("-")
 
+            year_part = parts[-2].strip()
+            month_part = parts[-1].strip()
+            if (
+                len(year_part) == 4
+                and year_part.isdigit()
+                and len(month_part) == 2
+                and month_part.isdigit()
+            ):
+                year = int(year_part)
+                month = int(month_part)
+                next_month_start = datetime.datetime(year, month, 1) + pd.DateOffset(
+                    months=1
+                )
+                return (
+                    matched_account,
+                    next_month_start - datetime.timedelta(days=1),
+                )
             if account_type == "bank":
+                # Legacy year-only format: bank-account-YYYY.pdf
                 date_part = parts[-1].strip()
                 if len(date_part) == 4 and date_part.isdigit():
                     year = int(date_part)
                     return matched_account, datetime.datetime(year, 12, 31)
-            else:  # cc
-                year_part = parts[-2].strip()
-                month_part = parts[-1].strip()
-                if (
-                    len(year_part) == 4
-                    and year_part.isdigit()
-                    and len(month_part) == 2
-                    and month_part.isdigit()
-                ):
-                    year = int(year_part)
-                    month = int(month_part)
-                    next_month_start = datetime.datetime(
-                        year, month, 1
-                    ) + pd.DateOffset(months=1)
-                    return (
-                        matched_account,
-                        next_month_start - datetime.timedelta(days=1),
-                    )
 
             logger.warning(
                 f"Could not parse standard date pattern from date part in filename '{filename}'"
@@ -383,6 +385,7 @@ class TransactionProcessor:
             f"Scanning {len(statement_files)} statement files for {account_type} transactions."
         )
 
+        seen_account_dates: set[tuple[str, Any]] = set()
         for file_info in statement_files:
             file_name, file_id = file_info.name, file_info.id
             if not file_id or account_type not in file_name.lower():
@@ -393,6 +396,15 @@ class TransactionProcessor:
             )
             if not matched_account:
                 continue
+
+            dedup_key = (matched_account, stmt_end_date)
+            if stmt_end_date and dedup_key in seen_account_dates:
+                logger.info(
+                    f"Skipping duplicate statement '{file_name}' (already processing this period)."
+                )
+                continue
+            if stmt_end_date:
+                seen_account_dates.add(dedup_key)
 
             last_txn_date = latest_txn_by_account.get(matched_account)
             if (
@@ -426,12 +438,18 @@ class TransactionProcessor:
                         if os.path.exists(pw_path):
                             with open(pw_path, "r") as f:
                                 pw_data = json.load(f)
-                                bank_name = (
-                                    matched_account.split("-")[1].lower()
-                                    if "-" in matched_account
+                                # Try account-specific key first (e.g. "axis-mini"),
+                                # fall back to bank-level key (e.g. "axis")
+                                parts = matched_account.split("-")
+                                specific_key = "-".join(parts[1:]).lower()
+                                bank_key = (
+                                    parts[1].lower()
+                                    if len(parts) > 1
                                     else matched_account.lower()
                                 )
-                                password = pw_data.get(bank_name, "")
+                                password = pw_data.get(
+                                    specific_key, pw_data.get(bank_key, "")
+                                )
                     except Exception as e:
                         logger.warning(
                             f"Failed to load password for {matched_account}: {e}"

--- a/src/transaction_processor.py
+++ b/src/transaction_processor.py
@@ -191,7 +191,7 @@ class TransactionProcessor:
                 return None
             return df
         except Exception as e:
-            log_and_exit(logger, f"Pandas DataFrame creation/cleaning failed: {e}", e)
+            logger.error(f"Pandas DataFrame creation/cleaning failed: {e}", exc_info=e)
             return None
 
     def _standardize_parsed_df(
@@ -231,12 +231,11 @@ class TransactionProcessor:
 
         # --- Date Parsing ---
         if "date" not in df.columns:
-            log_and_exit(
-                logger, "Standardized 'date' column not found. Cannot proceed."
-            )
+            logger.error("Standardized 'date' column not found. Cannot proceed.")
             return None
         try:
-            df["date"] = df["date"].apply(
+            df["date"] = df["date"].astype(object)
+            df.loc[:, "date"] = df["date"].apply(
                 lambda x: parse_mixed_datetime(logger, x, date_formats)
             )
             df.dropna(subset=["date"], inplace=True)
@@ -260,8 +259,9 @@ class TransactionProcessor:
             "amount" in df.columns and amount_sign_col and amount_sign_col in df.columns
         ):
             # Ensure the 'amount' column is numeric before applying sign
-            df["amount"] = df["amount"].apply(self._parse_amount)
-            df["amount"] = df.apply(
+            df["amount"] = df["amount"].astype(object)
+            df.loc[:, "amount"] = df["amount"].apply(self._parse_amount)
+            df.loc[:, "amount"] = df.apply(
                 lambda r: (
                     -r["amount"]
                     if (not debit_value and pd.isna(r.get(amount_sign_col)))
@@ -271,7 +271,8 @@ class TransactionProcessor:
                 axis=1,
             )
         elif "amount" in df.columns:
-            df["amount"] = df["amount"].apply(self._parse_amount)
+            df["amount"] = df["amount"].astype(object)
+            df.loc[:, "amount"] = df["amount"].apply(self._parse_amount)
         else:
             logger.error("Could not find columns to calculate amount.")
             return None
@@ -412,21 +413,71 @@ class TransactionProcessor:
                 continue
             config = PARSING_CONFIG[config_key]
 
-            # Use file_id (which is spreadsheet_id) and get first sheet name for data fetching
-            first_sheet_name = self.data_source.get_first_sheet_name_from_file(file_id)
-            if not first_sheet_name:
-                logger.warning(f"Cannot get sheet name for {file_id}. Skipping.")
-                continue
-
-            raw_statement_data = self.data_source.get_sheet_data(
-                file_id, first_sheet_name, "A:Z"
-            )
-            if not raw_statement_data:
-                logger.warning(f"No data from statement Sheet '{file_name}'. Skipping.")
-                continue
-
             try:
-                df = self._parse_statement_data_with_pandas(raw_statement_data, config)
+                if file_name.lower().endswith(".pdf"):
+                    logger.info(f"Processing statement PDF: '{file_name}'")
+                    pdf_bytes = self.data_source.download_file(file_id)
+                    password = ""
+                    try:
+                        import json
+                        import os
+
+                        pw_path = os.path.join("secrets", "passwords.json")
+                        if os.path.exists(pw_path):
+                            with open(pw_path, "r") as f:
+                                pw_data = json.load(f)
+                                bank_name = (
+                                    matched_account.split("-")[1].lower()
+                                    if "-" in matched_account
+                                    else matched_account.lower()
+                                )
+                                password = pw_data.get(bank_name, "")
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to load password for {matched_account}: {e}"
+                        )
+
+                    from src.pdf_parser import PDFParser
+
+                    parser = PDFParser()
+                    parsed_txns = parser.parse_pdf(pdf_bytes, password)
+                    if parsed_txns:
+                        df = pd.DataFrame(parsed_txns)
+                        df.replace("", pd.NA, inplace=True)
+                        config = {
+                            "column_map": {
+                                "date": "date",
+                                "description": "description",
+                                "debit": "debit",
+                                "credit": "credit",
+                            },
+                            "date_formats": ["%Y-%m-%d"],
+                        }
+                    else:
+                        df = None
+                else:
+                    first_sheet_name = self.data_source.get_first_sheet_name_from_file(
+                        file_id
+                    )
+                    if not first_sheet_name:
+                        logger.warning(
+                            f"Cannot get sheet name for {file_id}. Skipping."
+                        )
+                        continue
+
+                    raw_statement_data = self.data_source.get_sheet_data(
+                        file_id, first_sheet_name, "A:Z"
+                    )
+                    if not raw_statement_data:
+                        logger.warning(
+                            f"No data from statement Sheet '{file_name}'. Skipping."
+                        )
+                        continue
+
+                    df = self._parse_statement_data_with_pandas(
+                        raw_statement_data, config
+                    )
+
                 if df is not None and not df.empty:
                     std_df = self._standardize_parsed_df(df, config, matched_account)
                     if std_df is None or std_df.empty:
@@ -462,7 +513,7 @@ class TransactionProcessor:
                 else:
                     logger.info(f"0 txns or empty DataFrame from '{file_name}'.")
             except Exception as e:
-                log_and_exit(logger, f"Failed to process sheet '{file_name}': {e}", e)
+                logger.error(f"Failed to process sheet '{file_name}': {e}", exc_info=e)
 
         if all_parsed_txns:
             all_parsed_txns.sort(

--- a/tests/fixtures/e2e/statements/bank-axis-karti-2026-05.pdf
+++ b/tests/fixtures/e2e/statements/bank-axis-karti-2026-05.pdf
@@ -1,0 +1,74 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 612 792 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260525094015+05'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260525094015+05'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 585
+>>
+stream
+Gat%^fl#Ou&4PLP(&-)b?tMAB.5Gg]S$_A\`/T42Z'@SRQ\JPfk3i[TMrh>P#Y;bmiS6L^.M)k8IV2;]P2Yt45r#Z8-nR<^n$pKXMbl")/Q1/e/]EX08u5RdONa[^$I\-A6$O$+%'$M5OY(Qub>>@Eb?S*h?2lK8R,k;T(uop#>JI<jgfJc$/;mO$!SK97MqWM-VRuiYqq?O,F_R%Sa-pdZ'b+XQWWQ(&i<c:)pWIk;0>^_2N<>!l#iG2LQ"RG!k5DH2QaeP4\Xjo>rlF!4`:g:?V>W+c$ffK]04tH?2)%E8F+R6HnNocbfP:ZTNHI.1oN%m>o9pV)F3e&_S]:ZD\bp=!bnt?(iIiaU*7<tK?58)6#Dh+i`F]n.hc73n*Cgb]YRb;fSC1X,@jpJ$=EcWsHiI`AZ]@!/gDQ1m';*M+P-5Bb5UbeC)QhK_2+\FONo+6"HPUKX;fXWl")dZu*o9ZTEQ<KL[l#p/qcW5dpf/_)$gG=!`'\i+c7u,-AZWqucU-Sdp\L3G4^!C@m\<7R6p&NkBf6LIBl5fQ]uI)&=LFT5cFUj>UofsllfhI">B(Pt`'=".+&)~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000582 00000 n 
+0000000862 00000 n 
+0000000921 00000 n 
+trailer
+<<
+/ID 
+[<a0b1c2446a266b5c9e2ca090d6721e98><a0b1c2446a266b5c9e2ca090d6721e98>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1596
+%%EOF

--- a/tests/test_csv_data_source.py
+++ b/tests/test_csv_data_source.py
@@ -5,7 +5,6 @@ import csv
 import os
 from unittest.mock import patch
 import pytest
-
 from src.csv_data_source import CSVDataSource
 from src.constants import (
     BANK_TRANSACTIONS_SHEET_NAME,
@@ -40,34 +39,34 @@ def test_csv_data_source_init(temp_csv_dir):
 
 
 def test_list_statement_file_details(temp_csv_dir):
-    """Tests listing statement files in statements directory."""
+    """Tests listing statement files in statements directory (including PDFs)."""
     ds = CSVDataSource(temp_csv_dir)
 
     # Initially should be empty
     assert ds.list_statement_file_details() == []
 
-    # Add some CSV files
+    # Add some files
     statements_dir = os.path.join(temp_csv_dir, "statements")
     with open(os.path.join(statements_dir, "stat1.csv"), "w") as f:
         f.write("a,b,c")
     with open(os.path.join(statements_dir, "stat2.gsheet.csv"), "w") as f:
         f.write("x,y,z")
+    with open(os.path.join(statements_dir, "stat3.pdf"), "w") as f:
+        f.write("pdf")
     with open(os.path.join(statements_dir, "not_a_csv.txt"), "w") as f:
         f.write("hello")
 
     details = ds.list_statement_file_details()
-    assert len(details) == 2
-    # Ensure they are returned as DataSourceFile objects with filename as ID and name
+    assert len(details) == 3
     ids = {d.id for d in details}
     names = {d.name for d in details}
-    assert ids == {"stat1.csv", "stat2.gsheet.csv"}
-    assert names == {"stat1.csv", "stat2.gsheet.csv"}
+    assert ids == {"stat1.csv", "stat2.gsheet.csv", "stat3.pdf"}
+    assert names == {"stat1.csv", "stat2.gsheet.csv", "stat3.pdf"}
 
 
 def test_list_statement_file_details_nonexistent_dir(temp_csv_dir):
     """Tests listing statement files when statements directory does not exist."""
     ds = CSVDataSource(temp_csv_dir)
-    # Remove directory
     os.rmdir(ds.statements_path)
     assert ds.list_statement_file_details() == []
 
@@ -93,7 +92,6 @@ def test_get_sheet_data_statements(temp_csv_dir):
 def test_get_sheet_data_master_logs(temp_csv_dir):
     """Tests fetching sheet data for a master log when not found in statements."""
     ds = CSVDataSource(temp_csv_dir)
-    # Get sheet data for bank
     data = ds.get_sheet_data(BANK_TRANSACTIONS_SHEET_NAME, None, "A1:G2")
     assert data == [EXPECTED_SHEET_COLUMNS]
 
@@ -108,7 +106,6 @@ def test_get_sheet_data_not_found(temp_csv_dir):
 def test_get_sheet_data_exception(temp_csv_dir):
     """Tests exception handling during reading sheet data."""
     ds = CSVDataSource(temp_csv_dir)
-    # We patch builtins.open to raise an exception
     with patch("builtins.open", side_effect=Exception("Read error")):
         data = ds.get_sheet_data(f"{BANK_TRANSACTIONS_SHEET_NAME}.csv", None, "A1")
         assert data == []
@@ -187,7 +184,6 @@ def test_append_transactions_to_log_exception(temp_csv_dir):
     """Tests exception handling when appending transactions."""
     ds = CSVDataSource(temp_csv_dir)
     with patch("builtins.open", side_effect=Exception("Append error")):
-        # Should not raise exception
         ds.append_transactions_to_log("bank", [["row"]])
 
 
@@ -199,7 +195,6 @@ def test_clear_transaction_log_range(temp_csv_dir):
     ds.append_transactions_to_log("bank", [["2026-05-24", "Desc1"]])
     assert len(ds.get_transaction_log_data("bank")) == 2
 
-    # Clear
     ds.clear_transaction_log_range("bank")
     data = ds.get_transaction_log_data("bank")
     assert len(data) == 1
@@ -210,7 +205,6 @@ def test_clear_transaction_log_range_exception(temp_csv_dir):
     """Tests exception handling when clearing log range."""
     ds = CSVDataSource(temp_csv_dir)
     with patch("builtins.open", side_effect=Exception("Clear error")):
-        # Should not raise exception
         ds.clear_transaction_log_range("bank")
 
 
@@ -235,3 +229,15 @@ def test_get_first_sheet_name_from_file(temp_csv_dir):
     """Tests getting first sheet name."""
     ds = CSVDataSource(temp_csv_dir)
     assert ds.get_first_sheet_name_from_file("file.csv") == "Sheet1"
+
+
+def test_csv_data_source_download_file(temp_csv_dir):
+    """Tests downloading/reading local file bytes."""
+    ds = CSVDataSource(temp_csv_dir)
+    file_path = os.path.join(ds.statements_path, "statement.pdf")
+
+    with open(file_path, "wb") as f:
+        f.write(b"dummy pdf content")
+
+    content = ds.download_file("statement.pdf")
+    assert content == b"dummy pdf content"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -96,11 +96,12 @@ class TestGajanaE2E(unittest.TestCase):
         """
         Runs the E2E test for the PDF statement pathway (live LLM call).
         """
-        from src.pdf_parser import load_gemini_api_key
+        from src.pdf_parser import configure_api_keys, has_any_api_key
 
-        if not load_gemini_api_key():
+        configure_api_keys()
+        if not has_any_api_key():
             raise unittest.SkipTest(
-                "Neither GEMINI_API_KEY nor secrets/gemini.json is set. Skipping live LLM E2E test."
+                "No LLM API keys configured (GEMINI_API_KEY or ANTHROPIC_API_KEY). Skipping live LLM E2E test."
             )
 
         # 1. Setup initial state by copying fixtures

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -48,10 +48,9 @@ class TestGajanaE2E(unittest.TestCase):
                 f"CSV mismatch between {actual_path} and {expected_path}",
             )
 
-    def test_e2e_skeleton_no_op(self):
+    def test_e2e_csv_flow(self):
         """
-        Runs the E2E test skeleton with empty initial state and no statements.
-        This should result in an 'expected' state that remains empty (only headers).
+        Runs the E2E test for the CSV statement pathway.
         """
         # 1. Setup initial state by copying fixtures
         bank_initial = os.path.join(self.fixtures_dir, "bank_initial.csv")
@@ -68,14 +67,16 @@ class TestGajanaE2E(unittest.TestCase):
         shutil.copy(bank_initial, bank_work_path)
         shutil.copy(cc_initial, cc_work_path)
 
-        # Copy statement fixtures
+        # Copy ONLY CSV statement fixtures
         statements_fixture_dir = os.path.join(self.fixtures_dir, "statements")
-        if os.path.exists(self.statements_work_dir):
-            shutil.rmtree(self.statements_work_dir)
-        shutil.copytree(statements_fixture_dir, self.statements_work_dir)
+        for filename in os.listdir(statements_fixture_dir):
+            if filename.endswith(".csv"):
+                shutil.copy(
+                    os.path.join(statements_fixture_dir, filename),
+                    os.path.join(self.statements_work_dir, filename),
+                )
 
         # 2. Run the entire main.py in --update mode
-        # (Using --update flag which we added as an alias for normal mode)
         result = self._run_main(["--update"])
 
         if result.returncode != 0:
@@ -91,7 +92,57 @@ class TestGajanaE2E(unittest.TestCase):
         self._compare_csv_files(bank_work_path, bank_expected)
         self._compare_csv_files(cc_work_path, cc_expected)
 
-        # (File deletion happens in tearDown via directory removal)
+    def test_e2e_pdf_flow(self):
+        """
+        Runs the E2E test for the PDF statement pathway (live LLM call).
+        """
+        from src.pdf_parser import load_gemini_api_key
+
+        if not load_gemini_api_key():
+            raise unittest.SkipTest(
+                "Neither GEMINI_API_KEY nor secrets/gemini.json is set. Skipping live LLM E2E test."
+            )
+
+        # 1. Setup initial state by copying fixtures
+        bank_initial = os.path.join(self.fixtures_dir, "bank_initial.csv")
+        cc_initial = os.path.join(self.fixtures_dir, "cc_initial.csv")
+
+        bank_work_path = os.path.join(
+            self.working_dir, f"{BANK_TRANSACTIONS_SHEET_NAME}.csv"
+        )
+        cc_work_path = os.path.join(
+            self.working_dir, f"{CC_TRANSACTIONS_SHEET_NAME}.csv"
+        )
+
+        shutil.copy(bank_initial, bank_work_path)
+        shutil.copy(cc_initial, cc_work_path)
+
+        # Copy the PDF statement and credit card CSV statement
+        statements_fixture_dir = os.path.join(self.fixtures_dir, "statements")
+        shutil.copy(
+            os.path.join(statements_fixture_dir, "bank-axis-karti-2026-05.pdf"),
+            os.path.join(self.statements_work_dir, "bank-axis-karti-2026-05.pdf"),
+        )
+        shutil.copy(
+            os.path.join(statements_fixture_dir, "cc-axis-magnus-2026-05.csv"),
+            os.path.join(self.statements_work_dir, "cc-axis-magnus-2026-05.csv"),
+        )
+
+        # 2. Run the entire main.py in --update mode
+        result = self._run_main(["--update"])
+
+        if result.returncode != 0:
+            print(result.stdout)
+            print(result.stderr)
+
+        self.assertEqual(result.returncode, 0, "main.py failed to run")
+
+        # 3. Compare against expected output
+        bank_expected = os.path.join(self.fixtures_dir, "bank_expected.csv")
+        cc_expected = os.path.join(self.fixtures_dir, "cc_expected.csv")
+
+        self._compare_csv_files(bank_work_path, bank_expected)
+        self._compare_csv_files(cc_work_path, cc_expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -76,6 +76,9 @@ def test_data_source_interface_requires_all_methods_implemented():
         def get_first_sheet_name_from_file(self, file_id: str) -> Optional[str]:
             return None  # Implemented
 
+        def download_file(self, file_id: str) -> bytes:
+            return b""
+
     with pytest.raises(TypeError) as excinfo:
         IncompleteDataSource()  # type: ignore
     # The error message will list the missing abstract methods
@@ -110,6 +113,9 @@ def test_data_source_interface_requires_all_methods_implemented():
 
         def get_first_sheet_name_from_file(self, file_id: str) -> Optional[str]:
             return "Sheet1"
+
+        def download_file(self, file_id: str) -> bytes:
+            return b"dummy file contents"
 
     # This should not raise an error
     try:

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,5 +1,4 @@
 import io
-import os
 import json
 import pytest
 from unittest.mock import MagicMock, patch
@@ -17,34 +16,30 @@ def get_minimal_pdf_bytes(encrypted=False, password=""):
     return buf.getvalue()
 
 
+def make_llm_response(transactions: list) -> MagicMock:
+    mock = MagicMock()
+    mock.choices[0].message.content = json.dumps({"transactions": transactions})
+    return mock
+
+
 @pytest.fixture(autouse=True)
-def mock_load_gemini_api_key(monkeypatch):
+def mock_configure_api_keys(monkeypatch):
     from src import pdf_parser
 
-    monkeypatch.setattr(
-        pdf_parser,
-        "load_gemini_api_key",
-        lambda: os.environ.get("GEMINI_API_KEY", ""),
-    )
+    monkeypatch.setattr(pdf_parser, "configure_api_keys", lambda: None)
 
 
 def test_pdf_parser_no_api_key(monkeypatch):
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     parser = PDFParser()
-    assert parser.model is None
-    res = parser.parse_pdf(b"dummy pdf bytes")
-    assert res == []
+    assert parser.parse_pdf(b"dummy pdf bytes") == []
 
 
-@patch("google.generativeai.GenerativeModel")
-@patch("google.generativeai.configure")
-def test_pdf_parser_success(mock_configure, mock_model_class, monkeypatch):
+@patch("litellm.completion")
+def test_pdf_parser_success(mock_completion, monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    mock_model = MagicMock()
-    mock_model_class.return_value = mock_model
-
-    mock_response = MagicMock()
-    mock_response.text = json.dumps(
+    mock_completion.return_value = make_llm_response(
         [
             {
                 "date": "2026-05-02",
@@ -60,28 +55,20 @@ def test_pdf_parser_success(mock_configure, mock_model_class, monkeypatch):
             },
         ]
     )
-    mock_model.generate_content.return_value = mock_response
 
-    parser = PDFParser()
-    pdf_bytes = get_minimal_pdf_bytes()
-    txns = parser.parse_pdf(pdf_bytes)
+    txns = PDFParser().parse_pdf(get_minimal_pdf_bytes())
 
     assert len(txns) == 2
     assert txns[0]["description"] == "uber ride"
     assert txns[0]["debit"] == "200.00"
     assert txns[1]["credit"] == "50000.00"
+    mock_completion.assert_called_once()
 
-    mock_configure.assert_called_once_with(api_key="fake_key")
 
-
-@patch("google.generativeai.GenerativeModel")
-def test_pdf_parser_encrypted_success(mock_model_class, monkeypatch):
+@patch("litellm.completion")
+def test_pdf_parser_encrypted_success(mock_completion, monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    mock_model = MagicMock()
-    mock_model_class.return_value = mock_model
-
-    mock_response = MagicMock()
-    mock_response.text = json.dumps(
+    mock_completion.return_value = make_llm_response(
         [
             {
                 "date": "2026-05-02",
@@ -91,35 +78,70 @@ def test_pdf_parser_encrypted_success(mock_model_class, monkeypatch):
             }
         ]
     )
-    mock_model.generate_content.return_value = mock_response
 
-    parser = PDFParser()
-    pdf_bytes = get_minimal_pdf_bytes(encrypted=True, password="correctpassword")
-    txns = parser.parse_pdf(pdf_bytes, password="correctpassword")
+    txns = PDFParser().parse_pdf(
+        get_minimal_pdf_bytes(encrypted=True, password="correctpassword"),
+        password="correctpassword",
+    )
 
     assert len(txns) == 1
     assert txns[0]["description"] == "uber ride"
 
 
-@patch("google.generativeai.GenerativeModel")
-def test_pdf_parser_encrypted_wrong_password(mock_model_class, monkeypatch):
+@patch("litellm.completion")
+def test_pdf_parser_encrypted_wrong_password(mock_completion, monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    parser = PDFParser()
-    pdf_bytes = get_minimal_pdf_bytes(encrypted=True, password="correctpassword")
-    txns = parser.parse_pdf(pdf_bytes, password="wrongpassword")
+    txns = PDFParser().parse_pdf(
+        get_minimal_pdf_bytes(encrypted=True, password="correctpassword"),
+        password="wrongpassword",
+    )
     assert txns == []
+    mock_completion.assert_not_called()
+
+
+@patch("litellm.completion")
+def test_pdf_parser_encrypted_no_password(mock_completion, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    txns = PDFParser().parse_pdf(
+        get_minimal_pdf_bytes(encrypted=True, password="somepassword"),
+        password="",
+    )
+    assert txns == []
+    mock_completion.assert_not_called()
+
+
+@patch("litellm.completion")
+def test_pdf_parser_primary_fails_fallback_succeeds(mock_completion, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_anthropic_key")
+
+    fallback_response = make_llm_response(
+        [
+            {
+                "date": "2026-05-02",
+                "description": "fallback txn",
+                "debit": "20.00",
+                "credit": "",
+            }
+        ]
+    )
+    mock_completion.side_effect = [Exception("Primary unavailable"), fallback_response]
+
+    txns = PDFParser().parse_pdf(get_minimal_pdf_bytes())
+
+    assert len(txns) == 1
+    assert txns[0]["description"] == "fallback txn"
+    assert mock_completion.call_count == 2
 
 
 @patch("src.pdf_parser.PdfReader")
-@patch("google.generativeai.GenerativeModel")
-def test_pdf_parser_native_fails_fallback_success(
-    mock_model_class, mock_reader_class, monkeypatch
+@patch("litellm.completion")
+def test_pdf_parser_both_models_fail_text_extraction_succeeds(
+    mock_completion, mock_reader_class, monkeypatch
 ):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    mock_model = MagicMock()
-    mock_model_class.return_value = mock_model
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_anthropic_key")
 
-    # Mock reader and extracted text
     mock_reader = MagicMock()
     mock_reader_class.return_value = mock_reader
     mock_reader.is_encrypted = False
@@ -127,78 +149,89 @@ def test_pdf_parser_native_fails_fallback_success(
     mock_page.extract_text.return_value = "mocked extracted transaction text"
     mock_reader.pages = [mock_page]
 
-    # Native PDF call raises an error
-    mock_response = MagicMock()
-    mock_response.text = json.dumps(
+    text_response = make_llm_response(
         [
             {
                 "date": "2026-05-02",
-                "description": "fallback ride",
-                "debit": "20.00",
+                "description": "text txn",
+                "debit": "50.00",
                 "credit": "",
             }
         ]
     )
-    mock_model.generate_content.side_effect = [Exception("API limits"), mock_response]
+    mock_completion.side_effect = [
+        Exception("Primary PDF failed"),
+        Exception("Fallback PDF failed"),
+        text_response,
+    ]
 
-    parser = PDFParser()
-    pdf_bytes = get_minimal_pdf_bytes()
-    txns = parser.parse_pdf(pdf_bytes)
+    txns = PDFParser().parse_pdf(b"pdf_bytes")
 
     assert len(txns) == 1
-    assert txns[0]["description"] == "fallback ride"
-    assert mock_model.generate_content.call_count == 2
-
-
-def test_pdf_parser_encrypted_no_password(monkeypatch):
-    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    parser = PDFParser()
-    pdf_bytes = get_minimal_pdf_bytes(encrypted=True, password="somepassword")
-    txns = parser.parse_pdf(pdf_bytes, password="")
-    assert txns == []
+    assert txns[0]["description"] == "text txn"
+    assert mock_completion.call_count == 3
 
 
 @patch("src.pdf_parser.PdfReader")
-@patch("google.generativeai.GenerativeModel")
-def test_pdf_parser_fallback_empty_text(
-    mock_model_class, mock_reader_class, monkeypatch
+@patch("litellm.completion")
+def test_pdf_parser_all_fail_empty_text(
+    mock_completion, mock_reader_class, monkeypatch
 ):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    mock_model = MagicMock()
-    mock_model_class.return_value = mock_model
-    mock_model.generate_content.side_effect = Exception("API limits")
 
     mock_reader = MagicMock()
     mock_reader_class.return_value = mock_reader
     mock_reader.is_encrypted = False
     mock_page = MagicMock()
-    mock_page.extract_text.return_value = ""  # Empty text
+    mock_page.extract_text.return_value = ""
     mock_reader.pages = [mock_page]
 
-    parser = PDFParser()
-    txns = parser.parse_pdf(b"pdf_bytes")
+    mock_completion.side_effect = [
+        Exception("Primary failed"),
+        Exception("Fallback failed"),
+    ]
+
+    txns = PDFParser().parse_pdf(b"pdf_bytes")
     assert txns == []
 
 
-@patch("google.generativeai.GenerativeModel")
-def test_pdf_parser_json_decode_error(mock_model_class, monkeypatch):
+@patch("litellm.completion")
+def test_pdf_parser_json_decode_error(mock_completion, monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    mock_model = MagicMock()
-    mock_model_class.return_value = mock_model
+    bad_response = MagicMock()
+    bad_response.choices[0].message.content = "not valid json"
+    mock_completion.return_value = bad_response
 
-    mock_response = MagicMock()
-    mock_response.text = "invalid json response"
-    mock_model.generate_content.return_value = mock_response
-
-    parser = PDFParser()
-    txns = parser.parse_pdf(get_minimal_pdf_bytes())
+    txns = PDFParser().parse_pdf(get_minimal_pdf_bytes())
     assert txns == []
 
 
 @patch("src.pdf_parser.PdfReader")
 def test_pdf_parser_general_exception(mock_reader_class, monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
-    mock_reader_class.side_effect = Exception("Unexpected PDF corrupt error")
-    parser = PDFParser()
-    txns = parser.parse_pdf(b"dummy pdf bytes")
+    mock_reader_class.side_effect = Exception("Unexpected corrupt PDF")
+
+    txns = PDFParser().parse_pdf(b"dummy pdf bytes")
     assert txns == []
+
+
+@patch("litellm.completion")
+def test_pdf_parser_response_as_bare_array(mock_completion, monkeypatch):
+    """_parse_response handles bare JSON arrays (not wrapped in object)."""
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    bare_response = MagicMock()
+    bare_response.choices[0].message.content = json.dumps(
+        [
+            {
+                "date": "2026-05-01",
+                "description": "bare array txn",
+                "debit": "10",
+                "credit": "",
+            }
+        ]
+    )
+    mock_completion.return_value = bare_response
+
+    txns = PDFParser().parse_pdf(get_minimal_pdf_bytes())
+    assert len(txns) == 1
+    assert txns[0]["description"] == "bare array txn"

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,0 +1,204 @@
+import io
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from pypdf import PdfWriter
+from src.pdf_parser import PDFParser
+
+
+def get_minimal_pdf_bytes(encrypted=False, password=""):
+    writer = PdfWriter()
+    writer.add_blank_page(width=100, height=100)
+    if encrypted:
+        writer.encrypt(password)
+    buf = io.BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def mock_load_gemini_api_key(monkeypatch):
+    from src import pdf_parser
+
+    monkeypatch.setattr(
+        pdf_parser,
+        "load_gemini_api_key",
+        lambda: os.environ.get("GEMINI_API_KEY", ""),
+    )
+
+
+def test_pdf_parser_no_api_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    parser = PDFParser()
+    assert parser.model is None
+    res = parser.parse_pdf(b"dummy pdf bytes")
+    assert res == []
+
+
+@patch("google.generativeai.GenerativeModel")
+@patch("google.generativeai.configure")
+def test_pdf_parser_success(mock_configure, mock_model_class, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    mock_model = MagicMock()
+    mock_model_class.return_value = mock_model
+
+    mock_response = MagicMock()
+    mock_response.text = json.dumps(
+        [
+            {
+                "date": "2026-05-02",
+                "description": "uber ride",
+                "debit": "200.00",
+                "credit": "",
+            },
+            {
+                "date": "2026-05-03",
+                "description": "salary",
+                "debit": "",
+                "credit": "50000.00",
+            },
+        ]
+    )
+    mock_model.generate_content.return_value = mock_response
+
+    parser = PDFParser()
+    pdf_bytes = get_minimal_pdf_bytes()
+    txns = parser.parse_pdf(pdf_bytes)
+
+    assert len(txns) == 2
+    assert txns[0]["description"] == "uber ride"
+    assert txns[0]["debit"] == "200.00"
+    assert txns[1]["credit"] == "50000.00"
+
+    mock_configure.assert_called_once_with(api_key="fake_key")
+
+
+@patch("google.generativeai.GenerativeModel")
+def test_pdf_parser_encrypted_success(mock_model_class, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    mock_model = MagicMock()
+    mock_model_class.return_value = mock_model
+
+    mock_response = MagicMock()
+    mock_response.text = json.dumps(
+        [
+            {
+                "date": "2026-05-02",
+                "description": "uber ride",
+                "debit": "200.00",
+                "credit": "",
+            }
+        ]
+    )
+    mock_model.generate_content.return_value = mock_response
+
+    parser = PDFParser()
+    pdf_bytes = get_minimal_pdf_bytes(encrypted=True, password="correctpassword")
+    txns = parser.parse_pdf(pdf_bytes, password="correctpassword")
+
+    assert len(txns) == 1
+    assert txns[0]["description"] == "uber ride"
+
+
+@patch("google.generativeai.GenerativeModel")
+def test_pdf_parser_encrypted_wrong_password(mock_model_class, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    parser = PDFParser()
+    pdf_bytes = get_minimal_pdf_bytes(encrypted=True, password="correctpassword")
+    txns = parser.parse_pdf(pdf_bytes, password="wrongpassword")
+    assert txns == []
+
+
+@patch("src.pdf_parser.PdfReader")
+@patch("google.generativeai.GenerativeModel")
+def test_pdf_parser_native_fails_fallback_success(
+    mock_model_class, mock_reader_class, monkeypatch
+):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    mock_model = MagicMock()
+    mock_model_class.return_value = mock_model
+
+    # Mock reader and extracted text
+    mock_reader = MagicMock()
+    mock_reader_class.return_value = mock_reader
+    mock_reader.is_encrypted = False
+    mock_page = MagicMock()
+    mock_page.extract_text.return_value = "mocked extracted transaction text"
+    mock_reader.pages = [mock_page]
+
+    # Native PDF call raises an error
+    mock_response = MagicMock()
+    mock_response.text = json.dumps(
+        [
+            {
+                "date": "2026-05-02",
+                "description": "fallback ride",
+                "debit": "20.00",
+                "credit": "",
+            }
+        ]
+    )
+    mock_model.generate_content.side_effect = [Exception("API limits"), mock_response]
+
+    parser = PDFParser()
+    pdf_bytes = get_minimal_pdf_bytes()
+    txns = parser.parse_pdf(pdf_bytes)
+
+    assert len(txns) == 1
+    assert txns[0]["description"] == "fallback ride"
+    assert mock_model.generate_content.call_count == 2
+
+
+def test_pdf_parser_encrypted_no_password(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    parser = PDFParser()
+    pdf_bytes = get_minimal_pdf_bytes(encrypted=True, password="somepassword")
+    txns = parser.parse_pdf(pdf_bytes, password="")
+    assert txns == []
+
+
+@patch("src.pdf_parser.PdfReader")
+@patch("google.generativeai.GenerativeModel")
+def test_pdf_parser_fallback_empty_text(
+    mock_model_class, mock_reader_class, monkeypatch
+):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    mock_model = MagicMock()
+    mock_model_class.return_value = mock_model
+    mock_model.generate_content.side_effect = Exception("API limits")
+
+    mock_reader = MagicMock()
+    mock_reader_class.return_value = mock_reader
+    mock_reader.is_encrypted = False
+    mock_page = MagicMock()
+    mock_page.extract_text.return_value = ""  # Empty text
+    mock_reader.pages = [mock_page]
+
+    parser = PDFParser()
+    txns = parser.parse_pdf(b"pdf_bytes")
+    assert txns == []
+
+
+@patch("google.generativeai.GenerativeModel")
+def test_pdf_parser_json_decode_error(mock_model_class, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    mock_model = MagicMock()
+    mock_model_class.return_value = mock_model
+
+    mock_response = MagicMock()
+    mock_response.text = "invalid json response"
+    mock_model.generate_content.return_value = mock_response
+
+    parser = PDFParser()
+    txns = parser.parse_pdf(get_minimal_pdf_bytes())
+    assert txns == []
+
+
+@patch("src.pdf_parser.PdfReader")
+def test_pdf_parser_general_exception(mock_reader_class, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "fake_key")
+    mock_reader_class.side_effect = Exception("Unexpected PDF corrupt error")
+    parser = PDFParser()
+    txns = parser.parse_pdf(b"dummy pdf bytes")
+    assert txns == []

--- a/tests/test_transaction_processor.py
+++ b/tests/test_transaction_processor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
@@ -181,10 +181,8 @@ def test_parse_statement_data_pandas_creation_fails(transaction_processor, mocke
     mocker.patch("pandas.DataFrame", side_effect=Exception("Pandas Error"))
     config = {"header_patterns": []}
     raw_data = [["Col1"], ["Val1"]]
-    df = None
-    with pytest.raises(SystemExit):
-        df = transaction_processor._parse_statement_data_with_pandas(raw_data, config)
-    assert df is None
+    result = transaction_processor._parse_statement_data_with_pandas(raw_data, config)
+    assert result is None
 
 
 def test_standardize_parsed_df_empty_or_none_input(transaction_processor):
@@ -445,6 +443,54 @@ def test_get_new_transactions_from_statements(
     assert txn["category"] == DEFAULT_CATEGORY  # Check default category is added
 
 
+@patch("src.pdf_parser.PDFParser")
+def test_get_new_transactions_from_statements_pdf(
+    mock_pdf_parser_class, transaction_processor, mock_data_source, mocker
+):
+    """Tests that PDF statement files are correctly routed to PDFParser."""
+    mocker.patch("src.transaction_processor.BANK_ACCOUNTS", ["mini-sbi"])
+    mocker.patch(
+        "src.transaction_processor.PARSING_CONFIG",
+        {"bank-sbi": {}},
+    )
+
+    # Mock PDFParser and parse_pdf
+    mock_parser_instance = MagicMock()
+    mock_pdf_parser_class.return_value = mock_parser_instance
+    mock_parser_instance.parse_pdf.return_value = [
+        {
+            "date": "2024-01-25",
+            "description": "New PDF Purchase",
+            "debit": "150.00",
+            "credit": "",
+        },
+    ]
+
+    # Mock data source calls
+    mock_data_source.list_statement_file_details.return_value = [
+        DataSourceFile(id="filepdf123", name="bank-mini-sbi-2024.pdf")
+    ]
+    mock_data_source.download_file.return_value = b"pdf binary content"
+
+    latest_txn_by_account = {}
+
+    new_txns = transaction_processor.get_new_transactions_from_statements(
+        "bank", latest_txn_by_account
+    )
+
+    mock_data_source.list_statement_file_details.assert_called_once()
+    mock_data_source.download_file.assert_called_once_with("filepdf123")
+    mock_pdf_parser_class.assert_called_once()
+    mock_parser_instance.parse_pdf.assert_called_once_with(b"pdf binary content", "")
+
+    assert len(new_txns) == 1
+    txn = new_txns[0]
+    assert txn["date"] == datetime.datetime(2024, 1, 25)
+    assert txn["description"] == "New PDF Purchase"
+    assert txn["amount"] == -150.00  # Debit amount is converted to negative amount
+    assert txn["account"] == "mini-sbi"
+
+
 def test_get_new_transactions_skips_old_statement(
     transaction_processor, mock_data_source, mocker
 ):
@@ -496,13 +542,8 @@ def test_get_new_transactions_file_processing_fails(
         side_effect=Exception("Parse Fail"),
     )
 
-    with pytest.raises(SystemExit):
-        transaction_processor.get_new_transactions_from_statements("bank", {})
-    mock_log_and_exit_fixture.assert_called_once()
-    assert (
-        "Failed to process sheet 'bank-mini-sbi-2024.csv'"
-        in mock_log_and_exit_fixture.call_args[0][1]
-    )
+    result = transaction_processor.get_new_transactions_from_statements("bank", {})
+    assert result == []
 
 
 def test_format_txns_for_storage(transaction_processor):


### PR DESCRIPTION
## Summary

- Replaces `google-generativeai` with LiteLLM (unified SDK); primary model is `gemini/gemini-2.5-flash`, fallback is `anthropic/claude-sonnet-4-6`
- Fixes Claude PDF parsing (correct `document` content block instead of `image_url`) and strips markdown code fences from LLM responses before JSON parsing
- Adds per-session Gemini quota exhaustion flag — skips Gemini immediately once daily free-tier limit (20/day) is hit, falling back to Claude
- Fixes bank statement YYYY-MM filename date parsing (was returning `None` → all old bank PDFs re-processed every run, exhausting quota)
- Strips `_copy{N}` suffix before date parsing so duplicate Drive uploads get correct statement end date and are filtered correctly
- Deduplicates statements by `(account, period)` within a single run — only first copy is processed, rest skipped
- Supports per-account PDF passwords (e.g. `axis-mini` key takes precedence over `axis` fallback)
- Fixes Gmail fetcher headless OAuth to use fixed port 8081 with SSH tunnel instructions

## Test plan

- [ ] All 130 unit + e2e tests pass (enforced by pre-commit hooks)
- [ ] `python main.py --update` successfully added 309 new transactions (86 bank-axis-mini May 2026, 223 cc-hdfc-infiniametal Dec 2025–May 2026) via Claude fallback while Gemini quota was exhausted
- [ ] Duplicate copies (11x bank-axis-mini, 7x bank-axis-karti old months) correctly skipped in single run

🤖 Generated with [Claude Code](https://claude.com/claude-code)