### PR TITLE
feat: mirror bank cash movements into Cash Transactions ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ plugins/telegram_bot/settings.json
 
 # Personal ignore rules (copy data/ignore.example.json → data/ignore.json)
 data/ignore.json
+
+# Personal cash-mirror map (copy data/cash_mirror.example.json → data/cash_mirror.json)
+data/cash_mirror.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ statements (Google Drive / local CSV / PDF)
 
 **`SQLiteBackupManager`** (`src/backup_manager.py`) — backs up/restores transaction log to `backups/gajana.db`.
 
+**Cash mirror** (`src/cash_mirror.py`) — after new **bank** txns are booked in normal/daily mode, cash movements are mirrored into the shared "Cash Transactions" tab: an ATM withdrawal (bank debit) becomes a Cash **credit** (wallet gains cash); a cash deposit into the bank (bank credit) becomes a Cash **debit**. Which categories mirror, and their direction, comes from `data/cash_mirror.json` (`{category: "in"|"out"}`; `in` = wallet gains → Cash credit). Detection is category-based (categorizer must first label the txn, e.g. `Transfer:Cash` / `Transfer:Cash Deposit`). Idempotent across daily runs via a stable Remarks marker `auto:{account}:{date}:{amount}:{deschash}` — existing Cash rows are scanned and already-mirrored txns skipped. Only runs on data sources exposing a cash ledger (`GoogleDataSource`); no-op for CSV. Same tab is also written by the Telegram bot.
+
 **Gmail plugin** (`plugins/gmail_fetcher/`) — optional; downloads statements from Gmail before processing. Activated with `--fetch-emails` (requires `GoogleDataSource`).
 
 ### Statement parsing configuration

--- a/data/cash_mirror.example.json
+++ b/data/cash_mirror.example.json
@@ -1,0 +1,4 @@
+{
+  "Transfer:Cash": "in",
+  "Transfer:Cash Deposit": "out"
+}

--- a/data/matchers.example.json
+++ b/data/matchers.example.json
@@ -50,6 +50,17 @@
     ]
   },
   {
+    "category": "Transfer:Cash Deposit",
+    "debit": false,
+    "use_regex": true,
+    "description": [
+      "\\bcash dep",
+      "\\bcdm\\b",
+      "cash deposit",
+      "\\bby cash\\b"
+    ]
+  },
+  {
     "account": "bank-yourbank-secondary",
     "category": "Income:Salary",
     "debit": false,

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from typing import Any, Hashable
 
 from src import monitor
 from src.backup_manager import SQLiteBackupManager
+from src.cash_mirror import mirror_bank_cash_txns
 from src.categorizer import Categorizer
 from src.constants import (
     DEFAULT_CATEGORY,
@@ -196,6 +197,10 @@ def run_normal_mode(processor: TransactionProcessor, categorizer: Categorizer):
                 categorized_txns = categorizer.categorize(new_txns_to_add)
                 processor.add_new_transactions_to_log(categorized_txns, acc_type)
                 all_new_txns_added_count += len(categorized_txns)
+                # Bank cash movements (ATM withdrawals, cash deposits) mirror
+                # into the shared Cash Transactions ledger. No-op for cc.
+                if acc_type == "bank":
+                    mirror_bank_cash_txns(processor.data_source, categorized_txns)
             else:
                 logger.info(f"No new {acc_type} transactions found to add.")
         except Exception as e:  # Catch exceptions per account type processing

--- a/settings.example.json
+++ b/settings.example.json
@@ -3,6 +3,7 @@
   "google_sheets_transactions_id": "",
   "bank_transactions_sheet_name": "Bank transactions",
   "cc_transactions_sheet_name": "CC Transactions",
+  "cash_transactions_sheet_name": "Cash Transactions",
   "cc_accounts": [],
   "bank_accounts": []
 }

--- a/src/cash_mirror.py
+++ b/src/cash_mirror.py
@@ -1,0 +1,175 @@
+"""Mirror bank cash movements into the shared Cash Transactions ledger.
+
+An ATM/cash withdrawal shows up in a bank statement as a debit (money leaves the
+bank), but that cash physically enters the wallet -> it should appear as a
+*credit* (cash-in) in the Cash Transactions tab. A cash deposit into the bank is
+the reverse: a bank credit that removes cash from the wallet -> a Cash *debit*.
+
+Which bank categories to mirror, and in which direction, is configured in
+``data/cash_mirror.json`` (falls back to the committed ``.example``):
+
+    {"Transfer:Cash": "in", "Transfer:Cash Deposit": "out"}
+
+``in``  -> wallet gains cash -> Cash credit (positive).
+``out`` -> wallet loses cash -> Cash debit (negative).
+
+Idempotency: every mirrored row carries a stable marker in its Remarks column
+(``auto:{account}:{date}:{signed_amount}:{deschash}``). Before writing, existing
+Cash rows are scanned and any transaction whose marker is already present is
+skipped, so repeated daily runs never double-book.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import logging
+import os
+import re
+from typing import Any, Hashable
+
+logger = logging.getLogger(__name__)
+
+# Personal map lives in data/cash_mirror.json (gitignored); fall back to the
+# committed example so a fresh clone runs without extra setup.
+CASH_MIRROR_FILE_PATH = (
+    "data/cash_mirror.json"
+    if os.path.exists("data/cash_mirror.json")
+    else "data/cash_mirror.example.json"
+)
+
+MARKER_PREFIX = "auto"
+
+
+def load_cash_mirror_map(path: str = CASH_MIRROR_FILE_PATH) -> dict[str, str]:
+    """Loads the {category: "in"|"out"} mirror map. Missing/broken -> {}."""
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning(f"Failed to load cash-mirror map from {path}: {e}")
+        return {}
+    if not isinstance(data, dict):
+        logger.warning(f"Cash-mirror map {path} is not an object; ignoring it.")
+        return {}
+    out: dict[str, str] = {}
+    for cat, direction in data.items():
+        d = str(direction).strip().lower()
+        if d not in ("in", "out"):
+            logger.warning(
+                f"Cash-mirror map: category {cat!r} has invalid direction "
+                f"{direction!r} (want 'in'/'out'); skipping."
+            )
+            continue
+        out[str(cat)] = d
+    return out
+
+
+def _normalize(s: str) -> str:
+    """Lowercase alphanumerics only; robust to whitespace/punctuation drift."""
+    return re.sub(r"[^a-z0-9]", "", str(s).lower())
+
+
+def build_marker(txn: dict[Hashable, Any]) -> str:
+    """Stable per-transaction marker used to dedupe mirrored cash rows."""
+    date = txn.get("date")
+    date_str = (
+        date.strftime("%Y-%m-%d") if isinstance(date, datetime.datetime) else str(date)
+    )
+    try:
+        amount = float(txn.get("amount", 0.0))
+    except (ValueError, TypeError):
+        amount = 0.0
+    account = str(txn.get("account", ""))
+    desc_hash = hashlib.sha1(
+        _normalize(str(txn.get("description", ""))).encode("utf-8")
+    ).hexdigest()[:8]
+    return f"{MARKER_PREFIX}:{account}:{date_str}:{amount:.2f}:{desc_hash}"
+
+
+def _existing_markers(cash_rows: list[list[Any]]) -> set[str]:
+    """Extract markers already present in the Cash tab's Remarks column (idx 5,
+    for B3:G rows). Scans the whole cell so extra text around a marker is fine."""
+    markers: set[str] = set()
+    pat = re.compile(rf"{MARKER_PREFIX}:[^\s]+")
+    for row in cash_rows:
+        if len(row) < 6:
+            continue
+        for m in pat.findall(str(row[5])):
+            markers.add(m)
+    return markers
+
+
+def _cash_row(txn: dict[Hashable, Any], direction: str, marker: str) -> list[Any]:
+    """Build a Cash tab row (B:G) mirroring one bank cash transaction.
+
+    ``in`` -> Credit (wallet gains cash); ``out`` -> Debit (wallet loses cash).
+    Amount magnitude is taken from the bank txn regardless of its sign, so the
+    direction is driven purely by config, not by a possibly-mis-signed source.
+    """
+    date = txn.get("date")
+    date_str = (
+        date.strftime("%Y-%m-%d") if isinstance(date, datetime.datetime) else str(date)
+    )
+    try:
+        magnitude = abs(float(txn.get("amount", 0.0)))
+    except (ValueError, TypeError):
+        magnitude = 0.0
+    debit = "" if direction == "in" else f"{magnitude:.2f}"
+    credit = f"{magnitude:.2f}" if direction == "in" else ""
+    return [
+        date_str,
+        str(txn.get("description", "")),
+        debit,
+        credit,
+        str(txn.get("category", "")),
+        marker,
+    ]
+
+
+def mirror_bank_cash_txns(data_source: Any, txns: list[dict[Hashable, Any]]) -> int:
+    """Mirror bank cash movements in ``txns`` into the Cash Transactions tab.
+
+    Returns the number of rows written. No-op (returns 0) when the data source
+    has no cash ledger (e.g. CSVDataSource), the map is empty, or nothing
+    matches. Already-mirrored transactions are skipped via their Remarks marker.
+    """
+    if not txns:
+        return 0
+    if not (
+        hasattr(data_source, "get_cash_log_data")
+        and hasattr(data_source, "append_cash_rows")
+    ):
+        logger.debug("Data source has no cash ledger; skipping cash mirror.")
+        return 0
+
+    mirror_map = load_cash_mirror_map()
+    if not mirror_map:
+        return 0
+
+    candidates = [t for t in txns if str(t.get("category", "")) in mirror_map]
+    if not candidates:
+        return 0
+
+    existing = _existing_markers(data_source.get_cash_log_data())
+
+    rows: list[list[Any]] = []
+    seen: set[str] = set()  # guard against dupes within this same batch
+    for txn in candidates:
+        marker = build_marker(txn)
+        if marker in existing or marker in seen:
+            continue
+        seen.add(marker)
+        direction = mirror_map[str(txn.get("category"))]
+        rows.append(_cash_row(txn, direction, marker))
+
+    if not rows:
+        logger.info("Cash mirror: all matching bank txns already mirrored.")
+        return 0
+
+    data_source.append_cash_rows(rows)
+    logger.info(f"Cash mirror: wrote {len(rows)} row(s) to the Cash Transactions tab.")
+    return len(rows)

--- a/src/google_data_source.py
+++ b/src/google_data_source.py
@@ -21,6 +21,7 @@ from src.constants import (
     SERVICE_ACCOUNT_KEY_FILE,
     TRANSACTIONS_SHEET_ID,
 )
+from src.settings import CASH_TRANSACTIONS_SHEET_NAME
 from src.interfaces import DataSourceFile, DataSourceInterface
 from src.utils import log_and_exit
 
@@ -267,6 +268,35 @@ class GoogleDataSource(DataSourceInterface):
         updated_cells = result.get("updates", {}).get("updatedCells", 0)
         logger.info(f"Successfully appended {updated_cells} cells to {log_type} log.")
         return
+
+    # --- Cash ledger (shared with plugins/telegram_bot) ----------------------
+    @retry_on_gcp_error()
+    def get_cash_log_data(self) -> List[List[Any]]:
+        """Raw data rows (B3:G) from the Cash Transactions tab:
+        Date | Description | Debit | Credit | Category | Remarks."""
+        return self.get_sheet_data(
+            TRANSACTIONS_SHEET_ID, CASH_TRANSACTIONS_SHEET_NAME, "B3:G"
+        )
+
+    @retry_on_gcp_error()
+    def append_cash_rows(self, data_values: List[List[Any]]) -> None:
+        """Appends rows to the Cash Transactions tab (columns B:G)."""
+        if not data_values:
+            return
+        result = (
+            self.sheets_service.spreadsheets()
+            .values()
+            .append(
+                spreadsheetId=TRANSACTIONS_SHEET_ID,
+                range=f"'{CASH_TRANSACTIONS_SHEET_NAME}'!B:G",
+                valueInputOption="USER_ENTERED",
+                insertDataOption="INSERT_ROWS",
+                body={"values": data_values},
+            )
+            .execute()
+        )
+        updated = result.get("updates", {}).get("updatedCells", 0)
+        logger.info(f"Appended {updated} cells ({len(data_values)} rows) to cash log.")
 
     @retry_on_gcp_error()
     def clear_transaction_log_range(self, log_type: str, start_row: int = 3) -> None:

--- a/src/settings.py
+++ b/src/settings.py
@@ -28,6 +28,11 @@ CSV_FOLDER: str = _s["google_drive_csv_folder_id"]
 TRANSACTIONS_SHEET_ID: str = _s["google_sheets_transactions_id"]
 BANK_TRANSACTIONS_SHEET_NAME: str = _s["bank_transactions_sheet_name"]
 CC_TRANSACTIONS_SHEET_NAME: str = _s["cc_transactions_sheet_name"]
+# Single shared cash ledger tab (also written by plugins/telegram_bot). Optional
+# so pre-existing settings.json without the key still load.
+CASH_TRANSACTIONS_SHEET_NAME: str = _s.get(
+    "cash_transactions_sheet_name", "Cash Transactions"
+)
 CC_ACCOUNTS: list[str] = _s["cc_accounts"]
 BANK_ACCOUNTS: list[str] = _s["bank_accounts"]
 

--- a/tests/fixtures/settings.test.json
+++ b/tests/fixtures/settings.test.json
@@ -3,6 +3,11 @@
   "google_sheets_transactions_id": "test-sheet-id",
   "bank_transactions_sheet_name": "Bank transactions",
   "cc_transactions_sheet_name": "CC Transactions",
-  "cc_accounts": ["cc-axis-neo"],
-  "bank_accounts": ["bank-axis-primary"]
+  "cash_transactions_sheet_name": "Cash Transactions",
+  "cc_accounts": [
+    "cc-axis-neo"
+  ],
+  "bank_accounts": [
+    "bank-axis-primary"
+  ]
 }

--- a/tests/test_cash_mirror.py
+++ b/tests/test_cash_mirror.py
@@ -1,0 +1,117 @@
+"""Tests for the bank -> Cash Transactions mirror (src/cash_mirror.py)."""
+
+from __future__ import annotations
+
+import datetime
+import json
+
+import pytest
+
+from src import cash_mirror
+from src.cash_mirror import (
+    build_marker,
+    load_cash_mirror_map,
+    mirror_bank_cash_txns,
+)
+
+
+class FakeCashDataSource:
+    """Minimal stand-in exposing just the cash-ledger surface the mirror uses."""
+
+    def __init__(self, existing_rows=None):
+        self.existing_rows = existing_rows or []
+        self.appended: list[list] = []
+
+    def get_cash_log_data(self):
+        return self.existing_rows
+
+    def append_cash_rows(self, rows):
+        self.appended.extend(rows)
+
+
+class NoCashDataSource:
+    """A data source without a cash ledger (e.g. CSV)."""
+
+
+def _txn(desc, amount, category, account="bank-axis-primary", date=None):
+    return {
+        "date": date or datetime.datetime(2026, 5, 3),
+        "description": desc,
+        "amount": amount,
+        "category": category,
+        "account": account,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _map(monkeypatch, tmp_path):
+    """Point the mirror at a known map regardless of the repo's data/ files."""
+    p = tmp_path / "cash_mirror.json"
+    p.write_text(json.dumps({"Transfer:Cash": "in", "Transfer:Cash Deposit": "out"}))
+    monkeypatch.setattr(cash_mirror, "CASH_MIRROR_FILE_PATH", str(p))
+    return p
+
+
+def test_load_map_filters_invalid_directions(tmp_path):
+    p = tmp_path / "m.json"
+    p.write_text(json.dumps({"A": "in", "B": "sideways", "C": "OUT"}))
+    assert load_cash_mirror_map(str(p)) == {"A": "in", "C": "out"}
+
+
+def test_withdrawal_mirrors_as_credit():
+    ds = FakeCashDataSource()
+    n = mirror_bank_cash_txns(ds, [_txn("ATM CASH WDL", -2000, "Transfer:Cash")])
+    assert n == 1
+    date, desc, debit, credit, cat, remarks = ds.appended[0]
+    assert debit == "" and credit == "2000.00"
+    assert cat == "Transfer:Cash"
+    assert remarks.startswith("auto:bank-axis-primary:2026-05-03:-2000.00:")
+
+
+def test_deposit_mirrors_as_debit():
+    ds = FakeCashDataSource()
+    n = mirror_bank_cash_txns(ds, [_txn("CASH DEP BR", 5000, "Transfer:Cash Deposit")])
+    assert n == 1
+    _, _, debit, credit, _, _ = ds.appended[0]
+    assert debit == "5000.00" and credit == ""
+
+
+def test_non_cash_categories_ignored():
+    ds = FakeCashDataSource()
+    n = mirror_bank_cash_txns(ds, [_txn("ZOMATO", -300, "Expense:Dining")])
+    assert n == 0
+    assert ds.appended == []
+
+
+def test_already_mirrored_is_skipped():
+    txn = _txn("ATM CASH WDL", -2000, "Transfer:Cash")
+    marker = build_marker(txn)
+    existing = [["2026-05-03", "ATM CASH WDL", "", "2000.00", "Transfer:Cash", marker]]
+    ds = FakeCashDataSource(existing_rows=existing)
+    assert mirror_bank_cash_txns(ds, [txn]) == 0
+    assert ds.appended == []
+
+
+def test_duplicate_within_batch_written_once():
+    txn = _txn("ATM CASH WDL", -2000, "Transfer:Cash")
+    ds = FakeCashDataSource()
+    # Same txn twice in one batch -> identical marker -> only one row.
+    assert mirror_bank_cash_txns(ds, [dict(txn), dict(txn)]) == 1
+
+
+def test_same_day_amount_different_desc_not_confused():
+    ds = FakeCashDataSource()
+    t1 = _txn("ATM WDL HSR BRANCH", -2000, "Transfer:Cash")
+    t2 = _txn("ATM WDL KORAMANGALA", -2000, "Transfer:Cash")
+    assert mirror_bank_cash_txns(ds, [t1, t2]) == 2
+
+
+def test_data_source_without_cash_ledger_is_noop():
+    assert (
+        mirror_bank_cash_txns(NoCashDataSource(), [_txn("ATM", -100, "Transfer:Cash")])
+        == 0
+    )
+
+
+def test_empty_input():
+    assert mirror_bank_cash_txns(FakeCashDataSource(), []) == 0


### PR DESCRIPTION
## What

Bank ATM withdrawals and cash deposits now auto-generate a matching row in the shared **Cash Transactions** tab:

- **Withdrawal** (bank debit) → Cash **credit** (wallet gains cash)
- **Deposit** (bank credit) → Cash **debit** (wallet loses cash)

Direction is config-driven via `data/cash_mirror.json` (`{category: "in"|"out"}`), detected off the categorizer's label (`Transfer:Cash` / `Transfer:Cash Deposit`).

## Idempotency

Every mirrored row carries a stable Remarks marker `auto:{account}:{date}:{amount}:{deschash}`. Existing Cash rows are scanned each run and already-mirrored txns skipped — safe across daily reruns, coexists with the Telegram bot writing the same tab.

## Scope / safety

- Runs after **bank** booking in normal/`--daily` mode only (no-op for cc).
- Only fires on data sources exposing a cash ledger (`GoogleDataSource`); CSV is a no-op.
- Amount magnitude from the bank txn; direction from config, not source sign.

## Notes

- Live `matchers.json` `Transfer:Cash Deposit` keywords are best-guesses — verify against real statement deposit descriptions.
- 9 new tests in `tests/test_cash_mirror.py`; full suite (254) + mypy + flake8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)