### PR TITLE
chore: mark data/cash_mirror.json as runtime-mounted

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ secrets/
 settings.json
 plugins/gmail_fetcher/settings.json
 data/matchers.json
+data/cash_mirror.json
 data/llm_category_cache.json
 data/state/
 backups/


### PR DESCRIPTION
Follow-up to #15. `data/cash_mirror.json` is personal config bind-mounted from the homelab `./config` dir (never baked into the image), same class as `matchers.json`/`ignore.json`. Records that in `.dockerignore` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)