### PR TITLE
feat: write finance-summary feed from gajana, drop shared-key coupling

### DIFF
--- a/crontab
+++ b/crontab
@@ -10,6 +10,11 @@ SHELL=/bin/sh
 # Uptime-Kuma health heartbeat (see src/monitor.py).
 0 6 * * * cd /app && python main.py --daily
 
+# Hourly: refresh the Homepage finance-summary feed (data/finance/summary.json,
+# served credential-free by nginx). Net worth / XIRR / annual move slowly, so
+# hourly is plenty.
+0 * * * * cd /app && python -m src.finance_summary
+
 # Weekly Sunday 07:00 IST: back up Google Sheets to the local SQLite DB.
 0 7 * * 0 cd /app && python main.py --backup-db
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -1,6 +1,7 @@
 {
   "google_drive_csv_folder_id": "",
   "google_sheets_transactions_id": "",
+  "google_sheets_investments_id": "",
   "bank_transactions_sheet_name": "Bank transactions",
   "cc_transactions_sheet_name": "CC Transactions",
   "cash_transactions_sheet_name": "Cash Transactions",

--- a/src/finance_summary.py
+++ b/src/finance_summary.py
@@ -1,0 +1,172 @@
+"""Finance summary writer — emit the Homepage dashboard feed as a static JSON.
+
+Gajana already holds the Google service-account credentials, so it (not a
+separate service) reads the two sheets and writes ``data/finance/summary.json``.
+A credential-free nginx then serves that file. This module never starts a
+server; it is a batch job run hourly from cron.
+
+The output schema mirrors the previous interim ``finance-summary`` FastAPI
+service exactly, so the Homepage customapi mappings do not change:
+
+  * Investments (``Holding`` tab): net worth / portfolio value, invested,
+    profit, profit %, XIRR.
+  * Annual cash flow (``Yearly`` pivot, current-year column auto-detected):
+    income, regular expenses, new investments.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+from src.google_data_source import GoogleDataSource
+from src.interfaces import DataSourceInterface
+from src.settings import INVESTMENTS_SHEET_ID, TRANSACTIONS_SHEET_ID
+
+logger = logging.getLogger(__name__)
+
+# Container cwd is /app, so this resolves to /app/data/finance/summary.json.
+# The dir is mounted read-only into nginx; keep it dedicated to this feed.
+OUTPUT_PATH = os.environ.get("FINANCE_SUMMARY_OUTPUT", "data/finance/summary.json")
+
+# 'Yearly' pivot rows (col-A labels) pulled for the current-year column.
+ANNUAL_ROWS = {
+    "income": "Income",
+    "regular_expenses": "Regular Expenses",
+    "new_investments": "New Investments",
+}
+
+
+def _cell(grid: List[List[Any]], r: int, c: int = 0) -> Optional[Any]:
+    return grid[r][c] if r < len(grid) and c < len(grid[r]) else None
+
+
+def _num(s: Any) -> Optional[float]:
+    """Parse a formatted sheet value (₹1,39,54,452 / 56.80% / -₹19 / #N/A)."""
+    if s is None:
+        return None
+    s = str(s).strip()
+    if not s or s.startswith("#"):
+        return None
+    neg = s[0] in "-−"  # ascii minus or unicode minus
+    digits = re.sub(r"[^0-9.]", "", s)
+    if digits in ("", "."):
+        return None
+    v = float(digits)
+    return -v if neg else v
+
+
+def _inr(n: Optional[float]) -> str:
+    """Compact Indian currency: crore / lakh."""
+    if n is None:
+        return "—"
+    a = abs(n)
+    if a >= 1e7:
+        return f"₹{n / 1e7:.2f} Cr"
+    if a >= 1e5:
+        return f"₹{n / 1e5:.2f} L"
+    return f"₹{n:,.0f}"
+
+
+def _pct(s: Any) -> str:
+    v = _num(s)
+    return f"{v:.2f}%" if v is not None else "—"
+
+
+def _investments(ds: DataSourceInterface) -> Dict[str, Any]:
+    # 'Holding' scalar cells: B2 invested, B3 current value; M2 XIRR, M3 profit %.
+    b = ds.get_sheet_data(INVESTMENTS_SHEET_ID, "Holding", "B2:B3")
+    m = ds.get_sheet_data(INVESTMENTS_SHEET_ID, "Holding", "M2:M3")
+    invested = _num(_cell(b, 0))
+    value = _num(_cell(b, 1))
+    profit = value - invested if (value is not None and invested is not None) else None
+    return {
+        "value": value,
+        "invested": invested,
+        "profit": profit,
+        "xirr": _pct(_cell(m, 0)),
+        "profit_pct": _pct(_cell(m, 1)),
+    }
+
+
+def _annual(ds: DataSourceInterface) -> Dict[str, Any]:
+    grid = ds.get_sheet_data(TRANSACTIONS_SHEET_ID, "Yearly", "A2:AB200")
+    header = grid[0] if grid else []
+    rows = {r[0]: r for r in grid[1:] if r}
+    # Locate the current-year column by matching the header (fall back to latest).
+    yearcols: Dict[int, int] = {}
+    for i, h in enumerate(header):
+        try:
+            yearcols[int(str(h).strip())] = i
+        except ValueError:
+            pass
+    year = datetime.date.today().year
+    if year not in yearcols and yearcols:
+        year = max(yearcols)
+    col = yearcols.get(year)
+
+    def val(label: str) -> Optional[float]:
+        r = rows.get(label)
+        if not r or col is None or col >= len(r):
+            return None
+        return _num(r[col])
+
+    out: Dict[str, Any] = {"year": year}
+    for key, label in ANNUAL_ROWS.items():
+        out[key] = val(label)
+    return out
+
+
+def build_summary(ds: DataSourceInterface) -> Dict[str, Any]:
+    """Compute the full summary dict from the data source."""
+    inv = _investments(ds)
+    ann = _annual(ds)
+    return {
+        # investments
+        "net_worth": _inr(inv["value"]),
+        "net_worth_raw": inv["value"],
+        "portfolio_value": _inr(inv["value"]),
+        "invested": _inr(inv["invested"]),
+        "profit": _inr(inv["profit"]),
+        "profit_pct": inv["profit_pct"],
+        "xirr": inv["xirr"],
+        # annual cash flow (current year)
+        "year": ann["year"],
+        "income": _inr(ann["income"]),
+        "income_raw": ann["income"],
+        "regular_expenses": _inr(ann["regular_expenses"]),
+        "new_investments": _inr(ann["new_investments"]),
+        "updated": datetime.datetime.now().isoformat(timespec="seconds"),
+    }
+
+
+def write_summary(data: Dict[str, Any], path: str = OUTPUT_PATH) -> None:
+    """Atomically write the summary JSON (temp file in same dir + os.replace)."""
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    )
+    if not INVESTMENTS_SHEET_ID:
+        raise RuntimeError(
+            "google_sheets_investments_id not set in settings.json; "
+            "cannot build the finance summary."
+        )
+    ds = GoogleDataSource()
+    data = build_summary(ds)
+    write_summary(data)
+    logger.info("Wrote finance summary to %s: %s", OUTPUT_PATH, data)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/settings.py
+++ b/src/settings.py
@@ -26,6 +26,9 @@ _s = _load()
 
 CSV_FOLDER: str = _s["google_drive_csv_folder_id"]
 TRANSACTIONS_SHEET_ID: str = _s["google_sheets_transactions_id"]
+# Separate investment-portfolio spreadsheet, read by src/finance_summary.py.
+# Optional so pre-existing settings.json without the key still load.
+INVESTMENTS_SHEET_ID: str = _s.get("google_sheets_investments_id", "")
 BANK_TRANSACTIONS_SHEET_NAME: str = _s["bank_transactions_sheet_name"]
 CC_TRANSACTIONS_SHEET_NAME: str = _s["cc_transactions_sheet_name"]
 # Single shared cash ledger tab (also written by plugins/telegram_bot). Optional

--- a/tests/test_finance_summary.py
+++ b/tests/test_finance_summary.py
@@ -1,0 +1,124 @@
+"""Tests for the Homepage finance-summary writer (src/finance_summary.py)."""
+
+from __future__ import annotations
+
+import json
+
+from src import finance_summary
+from src.finance_summary import _inr, _num, _pct, build_summary, write_summary
+
+
+class FakeSheetsDataSource:
+    """Returns canned grids keyed by (sheet_name, range_spec)."""
+
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get_sheet_data(self, source_id, sheet_name, range_spec):
+        return self.responses.get((sheet_name, range_spec), [])
+
+
+def _ds():
+    # Values as the Sheets API returns them: FORMATTED_VALUE strings.
+    return FakeSheetsDataSource(
+        {
+            ("Holding", "B2:B3"): [["₹7,56,00,000"], ["₹11,85,00,000"]],
+            ("Holding", "M2:M3"): [["14.99%"], ["56.80%"]],
+            ("Yearly", "A2:AB200"): [
+                ["", "2025", "2026"],
+                ["Income", "₹1,00,00,000", "₹1,40,00,000"],
+                ["Regular Expenses", "₹20,00,000", "₹23,23,000"],
+                ["New Investments", "₹30,00,000", "₹42,51,000"],
+            ],
+        }
+    )
+
+
+class TestParsing:
+    def test_num_currency(self):
+        assert _num("₹1,39,54,452") == 13954452.0
+
+    def test_num_percent(self):
+        assert _num("56.80%") == 56.80
+
+    def test_num_unicode_minus(self):
+        assert _num("−₹19") == -19.0
+
+    def test_num_na_and_blank(self):
+        assert _num("#N/A") is None
+        assert _num("") is None
+        assert _num(None) is None
+
+    def test_inr_crore_lakh(self):
+        assert _inr(118500000) == "₹11.85 Cr"
+        assert _inr(2323000) == "₹23.23 L"
+        assert _inr(500) == "₹500"
+        assert _inr(None) == "—"
+
+    def test_pct(self):
+        assert _pct("14.99%") == "14.99%"
+        assert _pct("#N/A") == "—"
+
+
+class TestBuildSummary:
+    def test_full_schema(self):
+        out = build_summary(_ds())
+        # Investments
+        assert out["net_worth"] == "₹11.85 Cr"
+        assert out["net_worth_raw"] == 118500000.0
+        assert out["portfolio_value"] == "₹11.85 Cr"
+        assert out["invested"] == "₹7.56 Cr"
+        assert out["profit"] == "₹4.29 Cr"
+        assert out["profit_pct"] == "56.80%"
+        assert out["xirr"] == "14.99%"
+        # Annual (current-year column auto-detected)
+        assert out["year"] == 2026
+        assert out["income"] == "₹1.40 Cr"
+        assert out["income_raw"] == 14000000.0
+        assert out["regular_expenses"] == "₹23.23 L"
+        assert out["new_investments"] == "₹42.51 L"
+        # updated timestamp present
+        assert "updated" in out
+
+    def test_schema_keys_match_interim_contract(self):
+        # Homepage mappings depend on these exact keys.
+        out = build_summary(_ds())
+        expected = {
+            "net_worth",
+            "net_worth_raw",
+            "portfolio_value",
+            "invested",
+            "profit",
+            "profit_pct",
+            "xirr",
+            "year",
+            "income",
+            "income_raw",
+            "regular_expenses",
+            "new_investments",
+            "updated",
+        }
+        assert set(out.keys()) == expected
+
+    def test_missing_year_column_falls_back_to_latest(self, monkeypatch):
+        import datetime as _dt
+
+        class FrozenDate(_dt.date):
+            @classmethod
+            def today(cls):
+                return cls(2099, 1, 1)
+
+        monkeypatch.setattr(finance_summary.datetime, "date", FrozenDate)
+        out = build_summary(_ds())
+        assert out["year"] == 2026  # latest available header year
+        assert out["income"] == "₹1.40 Cr"
+
+
+class TestWriteSummary:
+    def test_atomic_write(self, tmp_path):
+        path = tmp_path / "finance" / "summary.json"
+        data = {"net_worth": "₹11.85 Cr", "year": 2026}
+        write_summary(data, str(path))
+        assert json.loads(path.read_text(encoding="utf-8")) == data
+        # temp file cleaned up by os.replace
+        assert not (tmp_path / "finance" / "summary.json.tmp").exists()


### PR DESCRIPTION
## What

Homepage's finance/investment widgets were fed by a separate `finance-summary` FastAPI service that read the Google Sheets via Gajana's service-account key, bind-mounted read-only. That coupled the widget to Gajana's secret path + key rotation.

This moves JSON production into Gajana itself (it already holds the creds).

## Changes

- New `src/finance_summary.py`: reads the `Holding` tab (net worth / invested / profit / XIRR) and the `Yearly` pivot (current-year income / expenses / new investments), computes the same schema the interim service exposed, and **atomically** writes `data/finance/summary.json`. Batch job, no server.
- Optional `google_sheets_investments_id` setting (`settings.py` + `settings.example.json`).
- Hourly crontab line (`0 * * * * python -m src.finance_summary`) — net worth / XIRR / annual move slowly.
- `tests/test_finance_summary.py` — parsing, schema contract, year fallback, atomic write.

A credential-free nginx serves the file (see the companion homelab PR), so nothing outside Gajana touches Google.

## Verification

- Full suite (292) + black/flake8/mypy green.
- Deployed live: output **byte-identical** to the interim `/summary` endpoint; hourly cron auto-firing and self-refreshing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)